### PR TITLE
Dynamic tile sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,4 @@
 <html>
-  <head>
-    <link rel="stylesheet" href="./index.css">
-  </head>
 <body>
   <h1>Icey</h1>
   <div id='moisture'></div>

--- a/src/board.js
+++ b/src/board.js
@@ -1,5 +1,5 @@
 // Renders well between ≈[6, whatever] to ≈[22, whatever]
-export const boardSize = [22, 2]
+export const boardSize = [10, 10]
 
 export const splitCoord = (coordString) => coordString.split(',').map(x => parseInt(x, 10))
 

--- a/src/board.js
+++ b/src/board.js
@@ -1,4 +1,6 @@
-export const boardSize = [50, 50]
+// Renders well between ≈[6, whatever] to ≈[22, whatever]
+export const boardSize = [22, 2]
+
 export const splitCoord = (coordString) => coordString.split(',').map(x => parseInt(x, 10))
 
 export const generateBoardCoordinates = () => {
@@ -43,13 +45,16 @@ const renderHex = (state, coord) => {
   )
 }
 
-export const renderBoard = (state) => {
+export const renderBoard = (state, boardSize) => {
   const boardHtml = boardCoordinates.reduce((acc, coord) => {
     acc += renderHex(state, coord)
     return acc
   }, '')
 
-  document.getElementById('board').innerHTML = boardHtml
+  const boardElement = document.getElementById('board')
+  boardElement.style.setProperty('--col-count', boardSize[0]);
+  boardElement.style.setProperty('--row-count', boardSize[1]);
+  boardElement.innerHTML = boardHtml
 }
 
 

--- a/src/board.scss
+++ b/src/board.scss
@@ -1,24 +1,29 @@
 #board {
+  --col-count: 10;
+  --row-count: 10;
+  --width: 150px;
+  width: calc((var(--col-count) + 2) * var(--width));
+  // width: 1784px;
   // width: 17840px;
-  width: 8150px;
+  // width: 8150px;
 }
 
 .hex {
-  width:150px;
-  height:86px;
+  width:var(--width);
+  height:calc(var(--width) * 0.57);
   background-color: #ccc;
   background-repeat: no-repeat;
   background-position: 50% 50%;
-  background-size: auto 173px;
+  background-size: auto calc(var(--width) * 1.15333);
   position: relative;
   float:left;
-  margin:25px 5px;
+  margin:calc(var(--width) * 0.16666) calc(var(--width) * 0.0333);
   text-align:center;
   zoom:1;
 }
 
   .hex.hex-gap {
-    margin-left: 86px;
+    margin-left: calc(var(--width) * 0.57);
   }
 
   .hex a {
@@ -55,8 +60,8 @@
 
   .hex .corner-1:before,
   .hex .corner-2:before {
-    width: 173px;
-    height:  173px;
+    width: calc(var(--width) * 1.15333);
+    height:  calc(var(--width) * 1.15333);
     content: '';
     position: absolute;
     background: inherit;
@@ -70,12 +75,12 @@
 
 
   .hex .corner-1:before {
-    transform: rotate(-60deg) translate(-87px, 0px);
+    transform: rotate(-60deg) translate(calc(var(--width) * -0.57), 0px);
     transform-origin: 0 0;
   }
 
   .hex .corner-2:before {
-    transform: rotate(60deg) translate(-48px, -11px);
+    transform: rotate(60deg) translate(calc(var(--width) * -0.285), calc(var(--width) * -0.073333));
     bottom:0;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import Simplex from 'perlin-simplex'
 
-import { renderBoard, splitCoord, boardCoordinates } from './board'
+import { renderBoard, splitCoord, boardCoordinates, boardSize } from './board'
 
 import './board.scss'
 
@@ -26,4 +26,4 @@ const updateBoard = () => {
 }
 
 
-renderBoard(boardState)
+renderBoard(boardState, boardSize)


### PR DESCRIPTION
![screen shot 2018-03-24 at 6 21 29 pm](https://user-images.githubusercontent.com/884489/37869580-3c0c6b02-2f90-11e8-98c5-e85a4baa5a89.png)

- The current parameters render correctly for `--col-count`s between 6
  and 22.  If we want `--col-count`s outside that range, then we will
  have to dynamically alter the fudge factor used to calculate the
  board width.  That is to say, we'll need to figure out how the fudge
  factor varies with the changes in `--col-count` and change the `+ 2`
  accordingly.

- By altering the `--width` we can control the size of the tiles.  I
  haven't explored its bounds, but we should be able to fine-tune it
  if we have an idea of the size of the tiles we want.

